### PR TITLE
fix: clone license repo

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           comment-summary-in-pr: true
           fail-on-severity: high
-          config-file: ./coveo-dependency-allowed-licenses/public.yml@main
+          config-file: ./coveo-dependency-allowed-licenses/public.yml
   private-undistributed:
     if: ${{ !inputs.public && inputs.distributed }}
     name: Dependency Review (Private Distributed)
@@ -48,7 +48,7 @@ jobs:
         with:
           comment-summary-in-pr: true
           fail-on-severity: high
-          config-file: ./coveo-dependency-allowed-licenses/private-distributed.yml@main
+          config-file: ./coveo-dependency-allowed-licenses/private-distributed.yml
   public-distributed:
     if: ${{ !inputs.public && !inputs.distributed }}
     name: Dependency Review (Private Undistributed)
@@ -66,4 +66,4 @@ jobs:
         with: 
           comment-summary-in-pr: true
           fail-on-severity: high
-          config-file: ./coveo-dependency-allowed-licenses/private-undistributed.yml@main
+          config-file: ./coveo-dependency-allowed-licenses/private-undistributed.yml

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,31 +18,52 @@ jobs:
     name: Dependency Review (Open Source)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/dependency-review-action@v3
+      - name: Checkout scan target
+        uses: actions/checkout@v3
+      - name: Checkout licenses
+        uses:  actions/checkout@v3
+        with:
+          ref: coveo/dependency-allowed-licenses
+          path: coveo-dependency-allowed-licenses
+      - name: Scan
+        uses: actions/dependency-review-action@v3
         with:
           comment-summary-in-pr: true
           fail-on-severity: high
-          config-file: coveo/dependency-allowed-licenses/public.yml@main
+          config-file: ./coveo-dependency-allowed-licenses/public.yml@main
   private-undistributed:
     if: ${{ !inputs.public && inputs.distributed }}
     name: Dependency Review (Private Distributed)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/dependency-review-action@v3
+      - name: Checkout scan target
+        uses: actions/checkout@v3
+      - name: Checkout licenses
+        uses:  actions/checkout@v3
+        with:
+          ref: coveo/dependency-allowed-licenses
+          path: coveo-dependency-allowed-licenses
+      - name: Scan
+        uses: actions/dependency-review-action@v3
         with:
           comment-summary-in-pr: true
           fail-on-severity: high
-          config-file: coveo/dependency-allowed-licenses/private-distributed.yml@main
+          config-file: ./coveo-dependency-allowed-licenses/private-distributed.yml@main
   public-distributed:
     if: ${{ !inputs.public && !inputs.distributed }}
     name: Dependency Review (Private Undistributed)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/dependency-review-action@v3
+      - name: Checkout scan target
+        uses: actions/checkout@v3
+      - name: Checkout licenses
+        uses:  actions/checkout@v3
+        with:
+          ref: coveo/dependency-allowed-licenses
+          path: coveo-dependency-allowed-licenses
+      - name: Scan
+        uses: actions/dependency-review-action@v3
         with: 
           comment-summary-in-pr: true
           fail-on-severity: high
-          config-file: coveo/dependency-allowed-licenses/private-undistributed.yml@main
+          config-file: ./coveo-dependency-allowed-licenses/private-undistributed.yml@main

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout licenses
         uses:  actions/checkout@v3
         with:
-          ref: coveo/dependency-allowed-licenses
+          repository: coveo/dependency-allowed-licenses
           path: coveo-dependency-allowed-licenses
       - name: Scan
         uses: actions/dependency-review-action@v3
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout licenses
         uses:  actions/checkout@v3
         with:
-          ref: coveo/dependency-allowed-licenses
+          repository: coveo/dependency-allowed-licenses
           path: coveo-dependency-allowed-licenses
       - name: Scan
         uses: actions/dependency-review-action@v3
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout licenses
         uses:  actions/checkout@v3
         with:
-          ref: coveo/dependency-allowed-licenses
+          repository: coveo/dependency-allowed-licenses
           path: coveo-dependency-allowed-licenses
       - name: Scan
         uses: actions/dependency-review-action@v3


### PR DESCRIPTION
DEF-720

----

Instead of letting `actions/dependency-review-actions` use the GH API to fetch the file (and thus hitting GH API limits), checkout the repo.