### PR TITLE
feat: add new maven workflows

### DIFF
--- a/.github/workflows/java-maven-openjdk11-codeql.yml
+++ b/.github/workflows/java-maven-openjdk11-codeql.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: 'The type of machine to run the job on. The machine can be either a GitHub-hosted runner, or a self-hosted runner.'
+        description: 'The type of machine to run the job on. Must be provided as a stringified list (e.g. `runs-on: '["ubuntu-latest","self-hosted"]'`)
         required: true
         type: string
       mvn-arguments:

--- a/.github/workflows/java-maven-openjdk11-codeql.yml
+++ b/.github/workflows/java-maven-openjdk11-codeql.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       runs-on:
+        description: 'The type of machine to run the job on. The machine can be either a GitHub-hosted runner, or a self-hosted runner.'
         required: true
         type: string
       mvn-arguments:

--- a/.github/workflows/java-maven-openjdk11-codeql.yml
+++ b/.github/workflows/java-maven-openjdk11-codeql.yml
@@ -1,0 +1,43 @@
+name: "CodeQL"
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: true
+        type: string
+      mvn-arguments:
+        required: false
+        type: string
+        default: '--also-make --batch-mode --strict-checksums --update-snapshots -Dmaven.gitcommitid.skip=true'
+
+jobs:
+  analyze-java:
+    name: Analyze Java
+
+    runs-on: ${{ fromJson(inputs.runs-on) }}
+
+    container:
+      image: adoptopenjdk/maven-openjdk11:latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: java
+
+      - name: Build project
+        run: mvn ${{ inputs.mvn-arguments }} clean test-compile
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:java"

--- a/.github/workflows/java-maven-openjdk11-dependency-submission.yml
+++ b/.github/workflows/java-maven-openjdk11-dependency-submission.yml
@@ -1,0 +1,36 @@
+name: 'Submit Maven Dependencies Snapshot'
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: true
+        type: string
+      directory:
+        description: 'The directory that contains the pom.xml that will be used to generate the dependency graph from'
+        default: '.'
+        required: false
+        type: string
+
+jobs:
+  submit-dependencies:
+    name: Submit dependencies
+
+    runs-on: ${{ fromJson(inputs.runs-on) }}
+
+    container:
+      image: adoptopenjdk/maven-openjdk11:latest
+
+    permissions:
+      actions: read
+      contents: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v3
+        with:
+          directory: ${{ inputs.directory }}

--- a/.github/workflows/java-maven-openjdk11-dependency-submission.yml
+++ b/.github/workflows/java-maven-openjdk11-dependency-submission.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       runs-on:
+        description: 'The type of machine to run the job on. The machine can be either a GitHub-hosted runner, or a self-hosted runner.'
         required: true
         type: string
       directory:

--- a/.github/workflows/java-maven-openjdk11-dependency-submission.yml
+++ b/.github/workflows/java-maven-openjdk11-dependency-submission.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: 'The type of machine to run the job on. The machine can be either a GitHub-hosted runner, or a self-hosted runner.'
+        description: 'The type of machine to run the job on. Must be provided as a stringified list (e.g. `runs-on: '["ubuntu-latest","self-hosted"]'`)
         required: true
         type: string
       directory:


### PR DESCRIPTION
Moving https://github.com/coveo/actions/blob/main/.github/workflows/java-maven-openjdk11-codeql.yml and https://github.com/coveo/actions/blob/main/.github/workflows/java-maven-openjdk11-dependency-submission.yml so they can be used by public repositories (and not run on self hosted runners)