### PR TITLE
feat(codeql): Cache maven dependencies

### DIFF
--- a/.github/workflows/java-maven-openjdk11-codeql.yml
+++ b/.github/workflows/java-maven-openjdk11-codeql.yml
@@ -28,6 +28,9 @@ jobs:
       security-events: write
 
     steps:
+      # Fix HOME variable as GitHub is overriding it, and it breaks assumptions from maven.
+      - run: echo "HOME=/root" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -35,7 +38,6 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: java
-
       - name: Cache maven dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/java-maven-openjdk11-codeql.yml
+++ b/.github/workflows/java-maven-openjdk11-codeql.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           languages: java
 
+      - name: Cache maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Build project
         run: mvn ${{ inputs.mvn-arguments }} clean test-compile
 

--- a/.github/workflows/java-maven-openjdk11-codeql.yml
+++ b/.github/workflows/java-maven-openjdk11-codeql.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: 'The type of machine to run the job on. Must be provided as a stringified list (e.g. `runs-on: '["ubuntu-latest","self-hosted"]'`)
+        description: |
+          The type of machine to run the job on. Must be provided as a stringified list (e.g. `runs-on: '["ubuntu-latest","self-hosted"]'`)
         required: true
         type: string
       mvn-arguments:


### PR DESCRIPTION
Add the cache action to cache maven dependencies when running CodeQL.

The action was tested against SearchAPI: https://github.com/coveo/searchapi/actions/runs/5014617033/jobs/8989094252?pr=5374

I had to change the environment variable to override the `HOME` variables. Since the container is running with the root user and its original `HOME` variable was `/root`, it was preventing me from caching the local repositories.

https://coveord.atlassian.net/browse/SEARCHAPI-8290