### PR TITLE
fix: Properly escape description in mvn dependency submission action

### DIFF
--- a/.github/workflows/java-maven-openjdk11-dependency-submission.yml
+++ b/.github/workflows/java-maven-openjdk11-dependency-submission.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: 'The type of machine to run the job on. Must be provided as a stringified list (e.g. `runs-on: '["ubuntu-latest","self-hosted"]'`)
+        description: |
+          The type of machine to run the job on. Must be provided as a stringified list (e.g. `runs-on: '["ubuntu-latest","self-hosted"]'`)
         required: true
         type: string
       directory:


### PR DESCRIPTION
The description wasn't properly escaped for this action as well.

https://coveord.atlassian.net/browse/SEARCHAPI-2628