### PR TITLE
dependency-review-action, specifies a pre-release version

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -53,7 +53,7 @@ jobs:
             core.setFailure(`Could not determine configuration for inputs: ${inputs}`)
 
       - name: Scan
-        uses: actions/dependency-review-action@v4
+       uses: actions/dependency-review-action@change-spdx-parser
         with:
           comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
           fail-on-severity: high

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -53,7 +53,7 @@ jobs:
             core.setFailure(`Could not determine configuration for inputs: ${inputs}`)
 
       - name: Scan
-       uses: actions/dependency-review-action@change-spdx-parser
+        uses: actions/dependency-review-action@change-spdx-parser
         with:
           comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
           fail-on-severity: high


### PR DESCRIPTION
As suggested in https://github.com/actions/dependency-review-action/issues/670#issuecomment-2027942677 , using the specific pre-release version of the action might resolve the issue with licenses.

In the doc repo, we've been having many failed builds because of it.

Example of this issue:
https://github.com/coveo/doc_jekyll-public-site/actions/runs/8909727612/job/24467591900
![image](https://github.com/coveo/doc_jekyll-public-site/assets/92988368/4634abf2-7caa-4a9d-80da-2fca3ef3dfd9)
