### PR TITLE
fix: patch-up support for `merge_group`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -58,3 +58,5 @@ jobs:
           comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
           fail-on-severity: high
           config-file: ./coveo-dependency-allowed-licenses/${{ steps.select-config.outputs.result }}
+          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
From https://github.com/actions/dependency-review-action/issues/456#issuecomment-1537840047, find out by @aboissinot-coveo 👏 

Will be fixed upstream by https://github.com/actions/dependency-review-action/pull/766.