### PR TITLE
fix: patch-up support for merge_group

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,6 +16,16 @@ on:
         required: false
         default: on-failure
         type: string
+      base-ref:
+        description: Provide custom git references for the git base
+        required: false
+        default: ${{ github.event.pull_request.base.sha }}
+        type: string
+      head-ref:
+        description: Provide custom git references for the git head
+        required: false
+        default: ${{ github.event.pull_request.head.sha }}
+        type: string
 
 jobs:
   dependency-review:
@@ -58,5 +68,5 @@ jobs:
           comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
           fail-on-severity: high
           config-file: ./coveo-dependency-allowed-licenses/${{ steps.select-config.outputs.result }}
-          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
-          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          base-ref: ${{ inputs.base-ref }}
+          head-ref: ${{ inputs.head-ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout licenses
-        uses:  actions/checkout@v4
+        uses: actions/checkout@v4
         with:
           repository: coveo/dependency-allowed-licenses
           path: coveo-dependency-allowed-licenses
@@ -58,3 +58,5 @@ jobs:
           comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
           fail-on-severity: high
           config-file: ./coveo-dependency-allowed-licenses/${{ steps.select-config.outputs.result }}
+          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
This is a patch so the `dependency-review` action can support `merge_group` triggers.

Workaround taken from: https://github.com/actions/dependency-review-action/issues/456#issuecomment-1537840047

Will be fixed upstream by https://github.com/actions/dependency-review-action/pull/766 made by @louis-bompart 🏆 