### PR TITLE
ci: Allow to pass maven arguments to dependency submission workflow

### DIFF
--- a/.github/workflows/java-maven-openjdk-dependency-submission.yml
+++ b/.github/workflows/java-maven-openjdk-dependency-submission.yml
@@ -24,6 +24,14 @@ on:
           The JDK version to use for the build.
         required: true
         type: number
+      mvn-additional-arguments:
+        description: |
+          The additional arguments to pass to the Maven invocation. You can use this to specify a custom profile for example.
+
+          If you wish to exclude certain modules from the scan, pass: -Dexcludes=groupId:artifactId:type:classifier
+
+        required: false
+        type: string
 
 jobs:
   submit-dependencies:
@@ -55,4 +63,4 @@ jobs:
         uses: advanced-security/maven-dependency-submission-action@v4
         with:
           directory: ${{ inputs.directory }}
-          maven-args: -Dscopes=compile,provided,runtime,system
+          maven-args: ${{ inputs.mvn-additional-arguments }} -Dscopes=compile,provided,runtime,system


### PR DESCRIPTION
# Proposed change

The dependency submission action now only report dependencies that are no in the test scope. That said, if you have a project that contains test-helpers, it will have dependencies that are not in the test-scope. It doesn’t necessary mean that they will reach production and thus, we should be able to exclude them.

I initially tried to exclude the modules by providing the following maven args: -pl !my-module-to-exclude but the plugin used doesn’t look at sub modules. It only execute the command in the parent pom.

I then leveraged the -Dexcludes=my-module:to-exclude parameter to exclude my module from the graph. Seems to work fine!

https://coveord.atlassian.net/browse/SEARCHAPI-10386