### PR TITLE
chore: temporary lock dep-review-action on 4.3.3

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -74,7 +74,7 @@ jobs:
             core.setFailure(`Could not determine configuration for inputs: ${inputs}`)
 
       - name: Scan
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.3.3
         with:
           comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
           fail-on-severity: ${{ inputs.fail-on-severity }}


### PR DESCRIPTION
4.3.4 introduce a new spdx parsing logic which I think blow stuff up. Let's first solve the problem live, then see what we can/should do to update.