### PR TITLE
Add audit renovate config action

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 .github/workflows/dependency-review.yml @coveo/dev-tooling-reviewers-1 @coveo/dev-tooling-reviewers-2 @coveo/dev-tooling-reviewers-3
+audit-renovate-config/** @coveo/dev-tooling @coveo/r-d-security-defence @coveo/cloud-intelligence

--- a/audit-renovate-config/action.yaml
+++ b/audit-renovate-config/action.yaml
@@ -1,0 +1,98 @@
+name: Audit Renovate Config
+description: Ensures that the renovate config files in the given repo only use allowed options.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - run: pip install pyjson5==1.6.6
+      shell: bash
+    - name: Check renovate config files
+      shell: python
+      run: |
+        from pathlib import Path
+        import re
+        import sys
+        import pyjson5
+
+        RENOVATE_FILES = [
+            Path("renovate.json"),
+            Path("renovate.json5"),
+            Path(".github/renovate.json"),
+            Path(".github/renovate.json5"),
+            Path(".gitlab/renovate.json"),
+            Path(".gitlab/renovate.json5"),
+            Path(".renovaterc"),
+            Path(".renovaterc.json"),
+            Path(".renovaterc.json5"),
+        ]
+
+
+        RED = "\x1b[31m"
+        RESET = "\x1b[0m"
+
+        fail = False
+
+
+        def check_config(config_path, config):
+            problems = []
+
+            def _record_failure(path, value):
+                problems.append((path, value))
+                global fail
+                fail = True
+                print(f"!!! {RED}Forbidden configuration detected{RESET}: {".".join(path)} = {value}")
+
+            def _check(path, key, value):
+                if key == "automerge" and value:
+                    _record_failure(path, value)
+
+                try:
+                    parent_key = path[-2]
+                except IndexError:
+                    parent_key = None
+
+                if parent_key == "extends":
+                    # Our presets
+                    if re.match(
+                        r"^github>(coveo|coveo-platform|coveo-dt-sandbox|coveooss|qubitdigital)/renovate-presets", value
+                    ):
+                        return
+                    # Official renovate presets
+                    if re.match(r"^[a-zA-Z]*:[a-zA-Z]+$", value):
+                        return
+                    # Not in the allowed list, fail
+                    _record_failure(path, value)
+
+            def _walk(path, key, value):
+                _check(path, key, value)
+
+                if isinstance(value, dict):
+                    for key, value in value.items():
+                        _walk(path + [key], key, value)
+                    return
+
+                if isinstance(value, list):
+                    for index, item in enumerate(value):
+                        _walk(path + [str(index)], str(index), item)
+                    return
+
+            _walk([], "ROOT", config)
+            if problems:
+                message = "%0A".join(f"{".".join(path)} = {value}" for path, value in problems)
+                print(f"::error file={config_path},title=Forbidden Renovate Configuration::{message}")
+
+
+        for p in RENOVATE_FILES:
+            if p.exists():
+                with p.open() as fp:
+                    config = pyjson5.decode_io(fp, None, False)
+                    print(f"Checking {p} ...")
+                    check_config(p, config)
+            else:
+                print(f"{p} does not exist, skipping")
+
+        if fail:
+            sys.exit(1)


### PR DESCRIPTION
This action audits all renovate configs in a repo to make sure that they:
- Don't set `automerge: true`
- Don't use untrusted presets

It's working like a charm and I tested it here: https://github.com/coveooss/tgf/pull/434