### PR TITLE
Harden actions based on Step Security recommendations

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -52,10 +52,15 @@ on:
         type: number
         default: 3
 
+permissions: {}
+
 jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ${{ fromJson(inputs.runs-on) }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.github/workflows/java-maven-openjdk-codeql.yml
+++ b/.github/workflows/java-maven-openjdk-codeql.yml
@@ -25,8 +25,7 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze-java:

--- a/.github/workflows/java-maven-openjdk-dependency-review.yml
+++ b/.github/workflows/java-maven-openjdk-dependency-review.yml
@@ -63,7 +63,7 @@ on:
         type: number
         default: 3
 
-permissions: { }
+permissions: {}
 
 jobs:
   submit-dependencies:

--- a/.github/workflows/java-maven-openjdk-dependency-submission.yml
+++ b/.github/workflows/java-maven-openjdk-dependency-submission.yml
@@ -34,8 +34,7 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   submit-dependencies:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,8 +16,7 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
-permissions: read-all
+permissions: { }
 
 jobs:
   analysis:
@@ -34,7 +33,18 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/test-dependency-review.yml
+++ b/.github/workflows/test-dependency-review.yml
@@ -2,12 +2,13 @@ name: Test Coveo Dependency Reviewer
 
 on: pull_request
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   test:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         public: [true, false]
@@ -23,6 +24,9 @@ jobs:
       runs-on: '["ubuntu-latest"]'
 
   test_v2:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         warn-on-openssf-scorecard-level: [5, 8]


### PR DESCRIPTION
J:DEF-3651

Hardening now that Step Security runs on all reusable workflows. It achieves two changes:
1. Reducing top level permissions to empty set, making sure job level permissions are defined.
2. Adds egress blocking mode to `scorecard.yml` since it is not reusable. This was tested [here](https://github.com/coveo/public-actions/actions/runs/12658465883)

### Permissions updates:

* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R55-R63): Added empty `permissions` at the top level and specified `contents: read` and `pull-requests: write` permissions for the `dependency-review` job.
* [`.github/workflows/java-maven-openjdk-codeql.yml`](diffhunk://#diff-664a6f9766028b778c4266f4907130c4f9b15adf028635544c44e1e22b36ec44L28-R28): Changed top-level `permissions` to an empty object. Job level already defines appropriate permissions.
* [`.github/workflows/java-maven-openjdk-dependency-submission.yml`](diffhunk://#diff-2923eb43ecf68f1ae7f26ba51359cdaa5914fa437c145eda368a0c58905c86bfL37-R37): Changed top-level `permissions` to an empty object. Job level already defines appropriate permissions.
* [`.github/workflows/scorecard.yml`](diffhunk://#diff-2e3112f4e81a9c47df8000638ce3b1b9ca15edcc82b228c207a7a4ff3bc7133fL19-R19): Changed top-level `permissions` to an empty object and updated the `Harden Runner` step to block egress and specify allowed endpoints. [[1]](diffhunk://#diff-2e3112f4e81a9c47df8000638ce3b1b9ca15edcc82b228c207a7a4ff3bc7133fL19-R19) [[2]](diffhunk://#diff-2e3112f4e81a9c47df8000638ce3b1b9ca15edcc82b228c207a7a4ff3bc7133fL37-R47)
* [`.github/workflows/test-dependency-review.yml`](diffhunk://#diff-84a354d1a1c83f12ba1433748d35ca1d1cec4e23a92d90f315aa55f18eec09d7L5-R11): Changed top-level `permissions` to an empty object and specified `contents: read` and `pull-requests: write` permissions for the `test` and `test_v2` jobs. [[1]](diffhunk://#diff-84a354d1a1c83f12ba1433748d35ca1d1cec4e23a92d90f315aa55f18eec09d7L5-R11) [[2]](diffhunk://#diff-84a354d1a1c83f12ba1433748d35ca1d1cec4e23a92d90f315aa55f18eec09d7R27-R29)

