### PR TITLE
chore(ci): scorecard egress policy fix

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,11 +34,12 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             api.github.com:443
             api.osv.dev:443
             api.securityscorecards.dev:443
+            api.deps.dev:443
             fulcio.sigstore.dev:443
             github.com:443
             oss-fuzz-build-logs.storage.googleapis.com:443


### PR DESCRIPTION
Fix the StepSecurity egress policy.

This pull request includes a change to the `jobs` section in the `.github/workflows/scorecard.yml` file to modify the egress policy and update the list of allowed endpoints.

* Changed the `egress-policy` from `block` to `audit` to allow monitoring of egress traffic instead of blocking it.
* Added `api.deps.dev:443` to the list of allowed endpoints.