### PR TITLE
feat(dep review): switch to dep-review 4.6.0 for Java projects

### DIFF
--- a/.github/workflows/java-maven-openjdk-dependency-review.yml
+++ b/.github/workflows/java-maven-openjdk-dependency-review.yml
@@ -84,7 +84,7 @@ jobs:
     needs: submit-dependencies
 
     name: Dependency Review
-    uses: ./.github/workflows/dependency-review-v2.yml
+    uses: ./.github/workflows/dependency-review-v3.yml
 
     permissions:
       contents: read

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@ audit-renovate-config/** @coveo/dev-tooling @coveo/r-d-security-defence @coveo/c
 .github/workflows/actions-codeql.yml @coveo/r-d-security-defence
 .github/workflows/dependency-review.yml @coveo/r-d-security-defence
 .github/workflows/dependency-review-v2.yml @coveo/r-d-security-defence
+.github/workflows/dependency-review-v3.yml @coveo/r-d-security-defence
 .github/workflows/java-maven-openjdk-codeql.yml @coveo/r-d-security-defence
 .github/workflows/java-maven-openjdk-dependency-review.yml @coveo/r-d-security-defence
 .github/workflows/java-maven-openjdk-dependency-submission.yml @coveo/r-d-security-defence


### PR DESCRIPTION
It looks like it works!

This pull request includes updates to the dependency review workflow and the `CODEOWNERS` file to ensure proper ownership and usage of the latest dependency review version.

Workflow updates:

* [`.github/workflows/java-maven-openjdk-dependency-review.yml`](diffhunk://#diff-5291b89f7598f1d35c12613e6a6aede37020b411bd86baa0332f006fd86ad055L87-R87): Updated the dependency review workflow to use version 3 (`dependency-review-v3.yml`) instead of version 2 (`dependency-review-v2.yml`).

Ownership updates:

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR7): Added ownership for the new `dependency-review-v3.yml` file to the `@coveo/r-d-security-defence` team.

J:DEF-2843