### PR TITLE
fix(dep review): undo the upgrade

### DIFF
--- a/.github/workflows/java-maven-openjdk-dependency-review.yml
+++ b/.github/workflows/java-maven-openjdk-dependency-review.yml
@@ -84,7 +84,7 @@ jobs:
     needs: submit-dependencies
 
     name: Dependency Review
-    uses: ./.github/workflows/dependency-review-v3.yml
+    uses: ./.github/workflows/dependency-review-v2.yml
 
     permissions:
       contents: read


### PR DESCRIPTION
J:DEF-2843

This pull request includes a change to the `.github/workflows/java-maven-openjdk-dependency-review.yml` file to revert the dependency review workflow to version 2.

Change in dependency review workflow:

* [`.github/workflows/java-maven-openjdk-dependency-review.yml`](diffhunk://#diff-5291b89f7598f1d35c12613e6a6aede37020b411bd86baa0332f006fd86ad055L87-R87): Reverted the dependency review workflow from version 3 to version 2.