### PR TITLE
feat: upgrade to dep review v3 java

### DIFF
--- a/.github/workflows/java-maven-openjdk-dependency-review.yml
+++ b/.github/workflows/java-maven-openjdk-dependency-review.yml
@@ -84,7 +84,7 @@ jobs:
     needs: submit-dependencies
 
     name: Dependency Review
-    uses: ./.github/workflows/dependency-review-v2.yml
+    uses: ./.github/workflows/dependency-review-v3.yml
 
     permissions:
       contents: read


### PR DESCRIPTION
This pull request updates the dependency review workflow to use the latest version, improving compatibility and functionality.

* [`.github/workflows/java-maven-openjdk-dependency-review.yml`](diffhunk://#diff-5291b89f7598f1d35c12613e6a6aede37020b411bd86baa0332f006fd86ad055L87-R87): Updated the workflow to use `dependency-review-v3.yml` instead of `dependency-review-v2.yml`.

J:DEF-2843