### PR TITLE
fix: dep review v3

### DIFF
--- a/.github/workflows/java-maven-openjdk-dependency-review.yml
+++ b/.github/workflows/java-maven-openjdk-dependency-review.yml
@@ -37,11 +37,6 @@ on:
         type: string
 
       # Dependency Reviewer inputs
-      comment-summary-in-pr:
-        description: Determines if the summary is posted as a comment in the PR itself. Setting this to `always` or `on-failure` requires you to give the workflow the write permissions for pull-requests
-        required: false
-        default: on-failure
-        type: string
       base-ref:
         description: Provide custom git references for the git base
         required: false
@@ -92,7 +87,6 @@ jobs:
 
     with:
       runs-on: ${{ inputs.runs-on }}
-      comment-summary-in-pr: ${{ inputs.comment-summary-in-pr }}
       base-ref: ${{ inputs.base-ref }}
       head-ref: ${{ inputs.head-ref }}
       fail-on-severity: ${{ inputs.fail-on-severity }}

--- a/.github/workflows/test-dependency-review.yml
+++ b/.github/workflows/test-dependency-review.yml
@@ -52,5 +52,4 @@ jobs:
     uses: ./.github/workflows/dependency-review-v3.yml
     with:
       warn-on-openssf-scorecard-level: ${{ matrix.warn-on-openssf-scorecard-level }}
-      comment-summary-in-pr: ${{ matrix.comment-summary-in-pr }}
       runs-on: '["ubuntu-latest"]'


### PR DESCRIPTION
J:DEF-2843

This pull request simplifies the configuration of dependency review workflows by removing the `comment-summary-in-pr` input parameter. The change ensures that workflows no longer require write permissions for pull requests to post summaries as comments.

### Simplification of dependency review workflows:

* [`.github/workflows/java-maven-openjdk-dependency-review.yml`](diffhunk://#diff-5291b89f7598f1d35c12613e6a6aede37020b411bd86baa0332f006fd86ad055L40-L44): Removed the `comment-summary-in-pr` input parameter, including its description and default value, from the workflow inputs.
* [`.github/workflows/java-maven-openjdk-dependency-review.yml`](diffhunk://#diff-5291b89f7598f1d35c12613e6a6aede37020b411bd86baa0332f006fd86ad055L95): Removed references to `comment-summary-in-pr` in the `jobs` section, simplifying the workflow configuration.
* [`.github/workflows/test-dependency-review.yml`](diffhunk://#diff-84a354d1a1c83f12ba1433748d35ca1d1cec4e23a92d90f315aa55f18eec09d7L55): Removed the `comment-summary-in-pr` parameter from the `jobs` section, aligning it with the updated dependency review workflow.